### PR TITLE
Whitelist Eclipse dependencies for OSGI Bundle Configurer

### DIFF
--- a/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/OsgiBundleConfigurer.groovy
+++ b/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/OsgiBundleConfigurer.groovy
@@ -7,16 +7,13 @@
  */
 package org.akhikhl.wuff
 
-import org.apache.commons.configuration.AbstractFileConfiguration
+import groovy.text.SimpleTemplateEngine
+import org.akhikhl.unpuzzle.PlatformConfig
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.apache.commons.lang3.StringEscapeUtils
-import groovy.text.SimpleTemplateEngine
-import groovy.xml.MarkupBuilder
 import org.gradle.api.Project
 import org.gradle.api.java.archives.Manifest
-import org.gradle.api.plugins.osgi.OsgiManifest
 import org.gradle.api.tasks.bundling.Jar
-import org.akhikhl.unpuzzle.PlatformConfig
 
 /**
  *
@@ -53,7 +50,7 @@ class OsgiBundleConfigurer extends JavaConfigurer {
         }
         if(proj)
           project.dependencies.add 'compile', proj
-        else
+        else if(bundleName.toString().startsWith("org.osgi") || bundleName.toString().startsWith("org.eclipse"))
           project.dependencies.add 'compile', "${project.ext.eclipseMavenGroup}:$bundleName:+"
       }
     }


### PR DESCRIPTION
If a project isn't found in the compile configuration, it doesn't mean we should automatically assume that it is an eclipse dependency. This commit adds a simple check for whitelisted eclipse dependencies.
