### PR TITLE
OsgiBundleConfigurer now supports non-"org.eclipse" and "org.osgi" Requie-Bundles.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ build
 .nb-gradle*
 *.iml
 .idea
+*.class
+libs/wuff-plugin/bin/

--- a/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/OsgiBundleConfigurer.groovy
+++ b/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/OsgiBundleConfigurer.groovy
@@ -48,12 +48,11 @@ class OsgiBundleConfigurer extends JavaConfigurer {
         def proj = project.rootProject.subprojects.find {
           it.ext.has('bundleSymbolicName') && it.ext.bundleSymbolicName == bundleName
         }
-        if(proj)
+        if(proj) {
           project.dependencies.add 'compile', proj
-        else if(bundleName.toString().startsWith("org.osgi") || bundleName.toString().startsWith("org.eclipse"))
+        } else {
           project.dependencies.add 'compile', "${project.ext.eclipseMavenGroup}:$bundleName:+"
-        else
-          project.logger.warn 'Bundle name {} could not be found', bundleName
+        }
       }
     }
     userManifest?.mainAttributes?.getValue('Require-Bundle')?.split(',')?.each { bundle ->


### PR DESCRIPTION
It'd be nice if there was a way to check that the dependencies are in the "mavenized" repo, but I'm not sure how that would work.
