### PR TITLE
Removed automatic detection of "fragmentHost" in LibWrapper.

### DIFF
--- a/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/LibWrapper.groovy
+++ b/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/LibWrapper.groovy
@@ -111,8 +111,6 @@ class LibWrapper {
         if(suffix.startsWith('-'))
           suffix = suffix.substring(1)
         if(suffix) {
-          if(suffix != 'patch')
-            fragmentHost = bundleName
           bundleName += '-' + suffix
         }
         bundleVersion = match[0][1]


### PR DESCRIPTION
I am mavenizing this jar:

http://maven.tmatesoft.com/content/repositories/releases/org/tmatesoft/svnkit/svnkit/1.8.6/svnkit-1.8.6.pom

Which has dependencies such as the following:

``` xml
<dependency>
    <groupId>com.trilead</groupId>
    <artifactId>trilead-ssh2</artifactId>
    <version>1.0.0-build217</version>
    <scope>compile</scope>
</dependency>
```

I was surprised when this plugin showed up as a Fragment, with no host to bind itself to.  Presumably this "Fragment" functionality is in here for a reason, in which case I expect you'll reject this PR.  Maybe there's a way to mark Fragments explicitly?
