### PR TITLE
Added a mechanism to allow a plugin to import a package from org.eclipse...

### DIFF
--- a/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/Config.groovy
+++ b/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/Config.groovy
@@ -29,6 +29,7 @@ class Config {
   boolean filterManifest = false
   boolean filterProperties = false
   boolean filterHtml = false
+  String eclipseImports = ''
 
   void eclipseVersion(String versionString, Closure closure) {
     List<Closure> closureList = lazyVersions[versionString]

--- a/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/OsgiBundleConfigurer.groovy
+++ b/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/OsgiBundleConfigurer.groovy
@@ -169,14 +169,25 @@ class OsgiBundleConfigurer extends JavaConfigurer {
             } else
               mergeValue = details.mergeValue
             String newValue
-            if(details.key.equalsIgnoreCase('Require-Bundle'))
+            if(details.key.equalsIgnoreCase('Require-Bundle')) {
               newValue = ManifestUtils.mergeRequireBundle(details.baseValue, mergeValue)
-            else if(details.key.equalsIgnoreCase('Import-Package') || details.key.equalsIgnoreCase('Export-Package'))
+            } else if(details.key.equalsIgnoreCase('Export-Package')) {
               newValue = ManifestUtils.mergePackageList(details.baseValue, mergeValue)
-            else if(details.key.equalsIgnoreCase('Bundle-ClassPath'))
+            } else if(details.key.equalsIgnoreCase('Import-Package')) {
+              newValue = ManifestUtils.mergePackageList(details.baseValue, mergeValue)
+              // if the user has specified specific eclipse imports, append them to the end
+              if (!project.wuff.eclipseImports.isEmpty()) {
+                if (newValue.isEmpty()) {
+                  newValue = project.wuff.eclipseImports
+                } else {
+                  newValue = newValue + ',' +project.wuff.eclipseImports
+                }
+              }
+            } else if(details.key.equalsIgnoreCase('Bundle-ClassPath')) {
               newValue = ManifestUtils.mergeClassPath(details.baseValue, mergeValue)
-            else
+            } else {
               newValue = mergeValue ?: details.baseValue
+            }
             if(newValue)
               details.value = newValue
             else


### PR DESCRIPTION
In ManifestUtils.groovy, line 101, function `mergePackageList` there is this little snippet:

``` groovy
    /*
     * Here we fix the problem with eclipse 4.X bundles:
     * if 'org.eclipse.xxx' are imported via 'Import-Package',
     * the application throws ClassNotFoundException.
     */
    packages = packages.findAll { !it.key.startsWith('org.eclipse') }
```

I have a bundle that creates a custom 'WorkbenchRendererFactory', the element that turns E4 elements into SWT widgets.  For some reason, this bundle _has_ to import some eclipse packages through the 'Import-Package' mechanism.  I've never understood how the dependency injection and classloading work together, I have to debug these issues by pure trial and error.

So for my "custom workbench renderer factory" plugin, I have the following line in my wuff configuration:

```
eclipseImports = 'org.eclipse.e4.ui.internal.workbench.swt,org.eclipse.e4.ui.workbench.swt.factories'
```

And now my build is 100% wuff!
