### PR TITLE
(DONT MERGE ME) I'm trying to ignore MANIFEST.MF, and I'm stuck

### DIFF
--- a/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/Config.groovy
+++ b/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/Config.groovy
@@ -29,6 +29,7 @@ class Config {
   boolean filterManifest = false
   boolean filterProperties = false
   boolean filterHtml = false
+  boolean ignoreManifest = true
 
   void eclipseVersion(String versionString, Closure closure) {
     List<Closure> closureList = lazyVersions[versionString]
@@ -97,6 +98,8 @@ class Config {
       target.filterProperties = true
     if(source.filterHtml)
       target.filterHtml = true
+    if(source.ignoreManifest)
+      target.ignoreManifest = true
   }
   
   boolean supportsE4() {

--- a/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/OsgiBundleConfigurer.groovy
+++ b/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/OsgiBundleConfigurer.groovy
@@ -504,15 +504,15 @@ class OsgiBundleConfigurer extends JavaConfigurer {
 
   protected void readManifest() {
     File userManifestFile = PluginUtils.findPluginManifestFile(project)
-    if(userManifestFile) {
+    println("project.wuff.ignoreManifest=" + project.wuff.ignoreManifest)
+    if (!project.wuff.ignoreManifest && userManifestFile != null) {
       userManifestFile.withInputStream {
         userManifest = new java.util.jar.Manifest(it)
       }
       def bundleSymbolicName = userManifest?.mainAttributes?.getValue('Bundle-SymbolicName')
       bundleSymbolicName = bundleSymbolicName.contains(';') ? bundleSymbolicName.split(';')[0] : bundleSymbolicName
       project.ext.bundleSymbolicName = bundleSymbolicName
-    }
-    else {
+    } else {
       userManifest = null
       project.ext.bundleSymbolicName = project.name
     }


### PR DESCRIPTION
Since Issue #35 (Provide option to keep original plugin.xml and MANIFEST.MF) is getting some attention this weekend, I figured I'd bring some attention to the opposite issue, to ignore the original MANIFEST.MF for a pure-wuff solution.

The code for OsgiBundleConfigurer.groovy works - if ignoreManifest is true, then Wuff will not parse the exisitng MANIFEST.MF.

The code for Config.groovy is broken.  It seems simple, but when I set `ignoreManifest = true` in my build.gradle, it doesn't get set inside Wuff.  So, I have set the default value to true (which I want, but probably not other users) and I'm punting the issue up to you ;-).

Seems like it would be great to have flags and defaults such as:
readManifest = true
writeManifest = true
overwriteOriginalManifest = false

Which I believe is the current behavior, but would allow for the various custom use-cases people are asking for.
