### PR TITLE
Fix missing attribute exception on custom launch parameter

### DIFF
--- a/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/EquinoxProductConfigurer.groovy
+++ b/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/EquinoxProductConfigurer.groovy
@@ -393,11 +393,11 @@ class EquinoxProductConfigurer {
     platform.applyPlatformSpecificCustomization()
 
     if(!launchParameters.empty || !jvmArgs.empty){
-      customizeIniFile(launchParameters, jvmArgs)
+      customizeIniFile(platform, launchParameters, jvmArgs)
     }
   }
 
-  private void customizeIniFile(List<String> launchParameters, List<String> jvmArgs){
+  private void customizeIniFile(Platform platform, List<String> launchParameters, List<String> jvmArgs){
     File iniFile = platform.iniFile
 
     StringBuffer buf = new StringBuffer()


### PR DESCRIPTION
I made a mistake in native launcher PR.
This branch fix MissingAttributeException when using launch parameters