### PR TITLE
Windows build issues

### DIFF
--- a/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/ArchiveUtils.groovy
+++ b/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/ArchiveUtils.groovy
@@ -39,10 +39,13 @@ class ArchiveUtils {
       if(!source.isAbsolute() && fromDir != null)
         source = new File(fromDir, source.path).canonicalFile
       String name = source.absolutePath
-      if(File.separator != '/')
+      String dirName = fromDir.absolutePath
+      if(File.separator != '/') {
         name = name.replace(File.separator, '/')
-      if(name.startsWith(fromDir.absolutePath)) {
-        name = name.substring(fromDir.absolutePath.length())
+        dirName = dirName.replace(File.separator, '/')
+      }
+      if(name.startsWith(dirName)) {
+        name = name.substring(dirName.length())
         if(name.startsWith('/'))
           name = name.substring(1)
       }

--- a/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/ManifestUtils.groovy
+++ b/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/ManifestUtils.groovy
@@ -108,8 +108,23 @@ class ManifestUtils {
   }
 
   static String mergeRequireBundle(String baseValue, String mergeValue) {
-    if(baseValue && mergeValue)
-      return ((baseValue.split(',') as Set) + (mergeValue.split(',') as Set)).join(',')
+    if(baseValue && mergeValue) {
+      Map bundles = [:]
+      List list = [baseValue, mergeValue].join(',').split(',').toList()
+      list.each { bundle ->
+        List bundleParams = bundle.split(';').toList()
+        String name = bundleParams.get(0)
+        List params = bundles.get(name) ?: []
+        if (bundleParams.size() > 1)
+          params.addAll(bundleParams[1..-1])
+        bundles.put(name, params)
+      }
+      return bundles.collect { it ->
+        List res = [it.key]
+        res.addAll(it.value as Set)
+        return res.join(';')
+      }.join(',')
+    }
     return mergeValue ?: baseValue
   }
 

--- a/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/PluginUtils.groovy
+++ b/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/PluginUtils.groovy
@@ -135,7 +135,8 @@ final class PluginUtils {
         pluginConfig = new File(pluginConfig)
       pluginConfig = new XmlParser().parse(pluginConfig)
     }
-    def classes = pluginConfig.extension.'**'.findAll({ it.'@class' })*.'@class' + pluginConfig.extension.'**'.findAll({ it.'@contributorClass' })*.'@contributorClass'
+    def classes = pluginConfig.extension.'**'.findAll({ it.hasProperty('@class') })*.'@class' + pluginConfig
+            .extension.'**'.findAll({ it.hasProperty('@contributorClass') })*.'@contributorClass'
     def packages = classes.findResults {
       int dotPos = it.lastIndexOf('.')
       dotPos >= 0 ? it.substring(0, dotPos) : null


### PR DESCRIPTION
I have stumbled upon two issues while converting our plugin from Maven build to Gradle.

1) No such property: @class for class: java.lang.String Possible solutions: class' at PluginUtils
2) In ArchiveUtils, paths were not correctly relativized on OS with a non-standard file separator, which created archives with absolute paths.