### PR TITLE
Merge required bundles with respect to modifiers.

### DIFF
--- a/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/ManifestUtils.groovy
+++ b/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/ManifestUtils.groovy
@@ -108,8 +108,23 @@ class ManifestUtils {
   }
 
   static String mergeRequireBundle(String baseValue, String mergeValue) {
-    if(baseValue && mergeValue)
-      return ((baseValue.split(',') as Set) + (mergeValue.split(',') as Set)).join(',')
+    if(baseValue && mergeValue) {
+      Map bundles = [:]
+      List list = [baseValue, mergeValue].join(',').split(',').toList()
+      list.each { bundle ->
+        List bundleParams = bundle.split(';').toList()
+        String name = bundleParams.get(0)
+        List params = bundles.get(name) ?: []
+        if (bundleParams.size() > 1)
+          params.addAll(bundleParams[1..-1])
+        bundles.put(name, params)
+      }
+      return bundles.collect { it ->
+        List res = [it.key]
+        res.addAll(it.value as Set)
+        return res.join(';')
+      }.join(',')
+    }
     return mergeValue ?: baseValue
   }
 


### PR DESCRIPTION
Previously, if MANIFEST.MF contained a Required-Bundle: with resolution:=optional, and wuff inferred that the bundle is required, the mergeRequireBundle received 'org.eclipse.package.name;resolution:=optional' in baseValue and 'org.eclipse.package.name' in mergeValue.

With the way the method worked, it yielded 'org.eclipse.package.name;resolution:=optional,org.eclipse.package.name', effectively marking the bundle as required. This patch addresses this issue by merging those modifiers in a naive way, that solves this issue.