### PR TITLE
Fixes build error 

### DIFF
--- a/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/PluginUtils.groovy
+++ b/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/PluginUtils.groovy
@@ -135,7 +135,8 @@ final class PluginUtils {
         pluginConfig = new File(pluginConfig)
       pluginConfig = new XmlParser().parse(pluginConfig)
     }
-    def classes = pluginConfig.extension.'**'.findAll({ it.'@class' })*.'@class' + pluginConfig.extension.'**'.findAll({ it.'@contributorClass' })*.'@contributorClass'
+    def classes = pluginConfig.extension.'**'.findAll({ it.hasProperty('@class') })*.'@class' + pluginConfig
+            .extension.'**'.findAll({ it.hasProperty('@contributorClass') })*.'@contributorClass'
     def packages = classes.findResults {
       int dotPos = it.lastIndexOf('.')
       dotPos >= 0 ? it.substring(0, dotPos) : null


### PR DESCRIPTION
Error 'No such property: @class for class: java.lang.String Possible solutions: class' sometimes happens, as pluginConfig.extension.'**' sometimes yields String instead of Node.
