### PR TITLE
Skip certain Require-Bundle or Import-Package entries

### DIFF
--- a/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/Config.groovy
+++ b/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/Config.groovy
@@ -30,6 +30,8 @@ class Config {
   boolean filterProperties = false
   boolean filterHtml = false
   String eclipseImports = ''
+  Set<String> skipRequireBundle = new LinkedHashSet()
+  Set<String> skipImportPackage = new LinkedHashSet()
 
   void eclipseVersion(String versionString, Closure closure) {
     List<Closure> closureList = lazyVersions[versionString]
@@ -98,6 +100,10 @@ class Config {
       target.filterProperties = true
     if(source.filterHtml)
       target.filterHtml = true
+    if(source.skipRequireBundle != null)
+      target.skipRequireBundle = source.skipRequireBundle;
+    if(source.skipImportPackage != null)
+      target.skipImportPackage = source.skipImportPackage;
   }
   
   boolean supportsE4() {


### PR DESCRIPTION
@akhikhl I read your [Wuff-bundle-files-draft](https://github.com/akhikhl/wuff-drafts/blob/master/Wuff-bundle-files-draft.md), however, I did not see any work done in that direction and I urgently needed a solution because of a project migration to Gradle that I'm working on at the moment.

This PR is far from a solution. I opened it up only as a suggestion of some sort. Perhaps it adds a bit to the idea of having the `generateBundleFiles = true` flag. In my case I'm interested in `Merge mode` with some slight exceptions to what is included in the `Require-Bundle` and  `Import-Package` fields.

This adds 2 new configuration options to the wuff configuration - `skipRequireBundle`
and `skipImportPackage`. These 2 define sets of String entries that Wuff will match and
remove from the final MANIFEST.MF file when merging the default and user-defined MANIFEST.MF files.

Example:

```
wuff {
    localMavenRepositoryDir = new File(System.getProperty('user.home'), '.wuff/m2_repository')

    wuffDir = new File(System.getProperty('user.home'), '.wuff')

    skipRequireBundle = ['org.eclipse.swt', 'org.eclipse.ui', 'org.eclipse.jface', 'org.eclipse.core.resources', 'org.eclipse.core.expressions']
    skipImportPackage = ['org.osgi.framework']
```

Disclaimer: I'm not a Groovy developer, so the code is probably quite poorly written.
