### PR TITLE
ManifestUtils.loadManifest returns a default manifest upon absence 

### DIFF
--- a/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/ManifestUtils.groovy
+++ b/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/ManifestUtils.groovy
@@ -70,9 +70,16 @@ class ManifestUtils {
       into tmpFolder
     }
     Manifest manifest
-    manifestFile.withInputStream {
-      manifest = new Manifest(it)
+
+    if(manifestFile.exists()) {
+      manifestFile.withInputStream {
+        manifest = new Manifest(it)
+      }
+      assert manifestFile.delete()
+    } else {
+      manifest = new Manifest()
     }
+
     return manifest
   }
 


### PR DESCRIPTION
I think there is currently a bug in ManifestUtils.loadManifest when it comes to jars without META-INF/MANIFEST.MF (for instance 'javax.inject:javax.inject:1'), as the method apparently always expects to find a manifest file. Since each call of loadManifest also replaces a previous temp file, a missing manifest file might actually get replaced by the still present manifest from the previous call (hence usually from another library), thus returning the wrong manifest, leading to strange effects. 

I propose to fix this by deleting the temp manifest file after reading it as well as by returning a default manifest in case the library did not contain an initial manifest. 